### PR TITLE
Added license information to package info.

### DIFF
--- a/src/models/AssetPackage.php
+++ b/src/models/AssetPackage.php
@@ -197,6 +197,9 @@ class AssetPackage extends Object
                     'reference' => $package->getDistReference(),
                 ];
             }
+            if($package->getLicense()) {
+                $release['license'] = $package->getLicense();
+            }
             if ($package->getSourceUrl()) {
                 $release['source'] = [
                     'type' => $package->getSourceType(),


### PR DESCRIPTION
As license information optional, but is highly recommended to supply, it's important to have it in package information if it possible.
documentation ref: https://getcomposer.org/doc/04-schema.md#license