### PR TITLE
Partial fix for case sensitivity problem

### DIFF
--- a/src/models/AssetPackage.php
+++ b/src/models/AssetPackage.php
@@ -172,7 +172,7 @@ class AssetPackage extends Object
     {
         $releases = [];
 
-        foreach ($pool->whatProvides($this->getFullName()) as $package) {
+        foreach ($pool->whatProvides($this->getNormalName()) as $package) {
             if ($package instanceof \Composer\Package\AliasPackage) {
                 continue;
             }


### PR DESCRIPTION
The change is very simple, see the diff.
What it gives: when updating upper-cased package e.g. `bower-asset/jquery.floatThead`
it will normalize (lowercase) name to `bower-asset/jquery.floatthead`
in the same way as composer does it.
So - this package will work.

But it creates the problem: different packages can lowercase to the same name.
e.g. `JQuery` and `jQuery`. 
So these packages will update same normalized package **jquery**.

So this fix is controversial and I would like to hear other people opinions.
Please comment!