### PR TITLE
Composer2: available-package-patterns

### DIFF
--- a/src/components/Storage.php
+++ b/src/components/Storage.php
@@ -206,6 +206,7 @@ class Storage extends Component implements StorageInterface
                     'sha256' => $hash,
                 ],
             ],
+            'available-package-patterns' => ['bower-asset/*', 'npm-asset/*'],
         ];
         $this->acquireLock();
         $filename = $this->buildPath('packages.json');


### PR DESCRIPTION
Composer 2 introduced a few new properties that can be added to the packages.json response, among others `available-packages` or `available-package-patterns` see [Composer upgrade documentation](https://github.com/composer/composer/blob/main/UPGRADE-2.0.md#metadata-url).

Setting either of them allows anyone using the Composer repository to skip fetching the provider files if the required packages do not match the defined names/patterns, resulting in less request against Asset Packagist.