### PR TITLE
Fix broken npm links for scoped packages on package details page

### DIFF
--- a/src/models/AssetPackage.php
+++ b/src/models/AssetPackage.php
@@ -45,6 +45,15 @@ class AssetPackage extends BaseObject
     }
 
     /**
+     * Reverses normalizeScopedName(): turns `scope--package` back into `@scope/package`,
+     * matching how npm actually names scoped packages in its own URLs.
+     */
+    public static function denormalizeScopedName($name)
+    {
+        return preg_replace('#^([^/]+?)--#', '@${1}/', $name, 1);
+    }
+
+    /**
      * AssetPackage constructor.
      * @param string $type
      * @param string $name
@@ -129,6 +138,14 @@ class AssetPackage extends BaseObject
     public function getName()
     {
         return $this->_name;
+    }
+
+    /**
+     * Name as used by the origin registry (npm), e.g. `@scope/package` instead of `scope--package`.
+     */
+    public function getRegistryName()
+    {
+        return static::denormalizeScopedName($this->_name);
     }
 
     public function getHash()

--- a/src/views/package/details.php
+++ b/src/views/package/details.php
@@ -23,7 +23,7 @@ $this->params['breadcrumbs'][] = $this->title;
             <small class="repository-link">
                 <?php
                 if ($package->getType() === 'npm') {
-                    $link = 'https://npmjs.com/package/' . $package->getName();
+                    $link = 'https://www.npmjs.com/package/' . $package->getRegistryName();
                 } elseif ($package->getType() === 'bower') {
                     $link = 'https://bower.io/search?q=' . $package->getName();
                 }

--- a/tests/unit/models/AssetPackageTest.php
+++ b/tests/unit/models/AssetPackageTest.php
@@ -35,4 +35,23 @@ class AssetPackageTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertSame($this->type . '-asset/' . $this->name, $this->object->getFullName());
     }
+
+    public function testGetRegistryNameUnscoped()
+    {
+        $this->assertSame($this->name, $this->object->getRegistryName());
+    }
+
+    public function testGetRegistryNameScoped()
+    {
+        $package = new AssetPackage('npm', 'ngneat--hot-toast');
+        $this->assertSame('@ngneat/hot-toast', $package->getRegistryName());
+    }
+
+    public function testNormalizeAndDenormalizeScopedNameRoundTrip()
+    {
+        $this->assertSame(
+            '@ngneat/hot-toast',
+            AssetPackage::denormalizeScopedName(AssetPackage::normalizeScopedName('@ngneat/hot-toast'))
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #154. The "see on Npm" link on the package details page (e.g. https://asset-packagist.org/package/npm-asset/ngneat--hot-toast) 404'd for every scoped npm package.

`AssetPackage::normalizeScopedName()` turns npm's `@scope/package` into this app's storage form `scope--package` (see `AssetPackage.php`), but `AssetPackage::getName()` returns that storage form as-is. `details.php` built the npm link directly from `getName()`, so a scoped package linked to `npmjs.com/package/ngneat--hot-toast` instead of the real `npmjs.com/package/@ngneat/hot-toast`.

- Added `AssetPackage::denormalizeScopedName()` — inverse of `normalizeScopedName()`, turns `scope--package` back into `@scope/package`.
- Added `AssetPackage::getRegistryName()` — the name as npm actually uses it.
- `details.php` now builds the npm link from `getRegistryName()`. Also switched to `www.npmjs.com` to match npm's canonical URL.
- Left `fetch-error.php`/`not-found.php` untouched — those build a search query (`npmjs.com/search?q=...`), not a direct package URL, so they're not affected by this 404.

Known limitation, not addressed here: since the storage form is lossy, a genuinely unscoped npm package whose name happens to contain `--` would now get an (incorrect) `@scope/...` link. Same class of ambiguity already exists elsewhere in this codebase's `--` scoping convention; not introduced by this change.

## Test plan
- [x] Added unit tests in `AssetPackageTest` covering unscoped names, scoped names, and the normalize/denormalize round-trip.
- [x] Manually verified against the real `AssetPackage` class (via the parent repo's autoloader) for `ngneat--hot-toast`, `types--lozad`, and `jquery` — all resolve to the correct npm URL form.
- [x] Not yet cherry-picked/verified on the prod `vendor/hiqdev/asset-packagist` checkout — will do before merge per repo convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected npm registry links for packages, including scoped packages.
  * Scoped package names now display in the standard `@scope/package` format.

* **Tests**
  * Added coverage for scoped and unscoped registry names.
  * Added validation for package-name conversion consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->