### PR TITLE
Refuse to overwrite existing releases with an empty fetch result

### DIFF
--- a/src/components/Storage.php
+++ b/src/components/Storage.php
@@ -107,17 +107,6 @@ class Storage extends Component implements StorageInterface
         $name = $package->getNormalName();
         $releases = $package->getReleases();
 
-        if (empty($releases)) {
-            $existing = $this->readPackage($package);
-            if ($existing !== null && !empty($existing['releases'])) {
-                throw new AssetFileStorageException(
-                    'Refusing to overwrite existing releases of "' . $name . '" with an empty release set '
-                    . '(the fetch likely failed or resolved to the wrong upstream name)',
-                    $package
-                );
-            }
-        }
-
         $data = [
             'packages' => [
                 $name => $releases,
@@ -130,6 +119,17 @@ class Storage extends Component implements StorageInterface
         $this->acquirePackageLock($name);
 
         try {
+            if (empty($releases)) {
+                $existing = $this->readPackage($package);
+                if ($existing !== null && !empty($existing['releases'])) {
+                    throw new AssetFileStorageException(
+                        'Refusing to overwrite existing releases of "' . $name . '" with an empty release set '
+                        . '(the fetch likely failed or resolved to the wrong upstream name)',
+                        $package
+                    );
+                }
+            }
+
             if ($this->shardNeedsWrite($path, $hash)) {
                 if ($this->mkdir(dirname($path)) === false) {
                     throw new AssetFileStorageException('Failed to create a directory for asset-package', $package);

--- a/src/components/Storage.php
+++ b/src/components/Storage.php
@@ -105,9 +105,22 @@ class Storage extends Component implements StorageInterface
     public function writePackage(AssetPackage $package)
     {
         $name = $package->getNormalName();
+        $releases = $package->getReleases();
+
+        if (empty($releases)) {
+            $existing = $this->readPackage($package);
+            if ($existing !== null && !empty($existing['releases'])) {
+                throw new AssetFileStorageException(
+                    'Refusing to overwrite existing releases of "' . $name . '" with an empty release set '
+                    . '(the fetch likely failed or resolved to the wrong upstream name)',
+                    $package
+                );
+            }
+        }
+
         $data = [
             'packages' => [
-                $name => $package->getReleases(),
+                $name => $releases,
             ],
         ];
         $json = Json::encode($data);

--- a/tests/unit/models/StorageTest.php
+++ b/tests/unit/models/StorageTest.php
@@ -11,6 +11,7 @@
 namespace hiqdev\assetpackagist\tests\unit\models;
 
 use hiqdev\assetpackagist\components\Storage;
+use hiqdev\assetpackagist\exceptions\AssetFileStorageException;
 use hiqdev\assetpackagist\models\AssetPackage;
 use Yii;
 use yii\helpers\Json;
@@ -251,6 +252,50 @@ class StorageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             $json,
             file_get_contents($this->storageDir . "/p/bower-asset/jquery/{$hash}.json")
+        );
+    }
+
+    public function testWritePackageRefusesToBlankExistingReleases()
+    {
+        $existingJson = Json::encode([
+            'packages' => [
+                'bower-asset/jquery' => [
+                    '3.6.0' => ['name' => 'bower-asset/jquery', 'version' => '3.6.0'],
+                ],
+            ],
+        ]);
+        $existingHash = hash('sha256', $existingJson);
+
+        $this->writeShard('p/bower-asset/jquery/latest.json', $existingJson);
+        $this->writeShard("p/bower-asset/jquery/{$existingHash}.json", $existingJson);
+
+        // freshly constructed, never loaded/updated -> getReleases() is empty,
+        // simulating a fetch that resolved to nothing (case mismatch, registry hiccup, ...)
+        $package = new AssetPackage('bower', 'jquery');
+
+        $this->expectException(AssetFileStorageException::class);
+
+        try {
+            $this->object->writePackage($package);
+        } finally {
+            $this->assertSame(
+                $existingJson,
+                file_get_contents($this->storageDir . '/p/bower-asset/jquery/latest.json'),
+                'existing releases must survive an empty-release write attempt'
+            );
+        }
+    }
+
+    public function testWritePackageAllowsEmptyReleasesWhenNothingExistedBefore()
+    {
+        $package = new AssetPackage('bower', 'new-package');
+
+        $this->object->writePackage($package);
+
+        $expectedJson = Json::encode(['packages' => ['bower-asset/new-package' => []]]);
+        $this->assertSame(
+            $expectedJson,
+            file_get_contents($this->storageDir . '/p/bower-asset/new-package/latest.json')
         );
     }
 }


### PR DESCRIPTION
## Summary

Found while investigating #157 (package hijacking). The reported hijack mechanism itself (`AssetVcsRepository::initTags()` walking every raw git tag regardless of whether npm ever published it under that name) lives in `fxp/composer-asset-plugin`, outside this repo's control — closing #157 with that explanation.

While verifying it, found a more directly exploitable bug in this repo: `Storage::writePackage()` persists whatever `AssetPackage::getReleases()` returns with no check against what's already on disk.

`PackageController::actionUpdate` applies no name validation on the `query` POST param (unlike `actionSearch`, which does). `AssetPackage::update()` fetches from the registry using the raw, un-normalized name (`getFullName()`), while `Storage::writePackage()` writes under the lowercased/normalized name (`getNormalName()`). npm's registry is case-sensitive, so a query like `npm-asset/LODASH` 404s on fetch; `fxp\Composer\AssetPlugin\Repository\AbstractAssetsRepository::fallbackWathProvides()` swallows 404s into an empty provider list rather than throwing (and npm's `search()` override always returns `[]`, so no fallback resolution happens either). The empty release set then gets written straight over the real `npm-asset/lodash` data.

Net effect: an unauthenticated POST to `/package/update` with a case-mangled name silently blanks a live package's release history, propagating through `provider-latest` and `packages.json`. Only defense today is the existing 10-minute per-package rate limit, which doesn't prevent triggering it once, and is parallelizable across the whole package corpus.

## Fix

`Storage::writePackage()` now reads the existing on-disk release set before writing, and refuses the write when it would replace existing non-empty releases with an empty set. New packages are unaffected — there's nothing on disk to protect yet.

## Test plan

- [x] Added `StorageTest::testWritePackageRefusesToBlankExistingReleases` — writes a real release fixture to disk, then constructs an `AssetPackage` with empty releases (simulating a failed/misrouted fetch) and asserts `writePackage()` throws and the on-disk data is untouched.
- [x] Added `StorageTest::testWritePackageAllowsEmptyReleasesWhenNothingExistedBefore` — confirms brand-new packages can still be written with zero releases (no regression).
- [x] Ran the full `StorageTest` suite locally (PHP 8.5, PHPUnit 9, `--ignore-platform-reqs` — this repo can't install cleanly under modern PHP/Composer, see #195): 13/13 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented existing package release data from being accidentally cleared by an empty update.
  * Updates that would remove existing releases now fail safely while preserving current data.
  * Empty release sets remain supported when creating a package for the first time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->